### PR TITLE
Fix flaky test assumption

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -22,7 +22,7 @@ test("seeded", function (assert) {
     var ts = time()
     var ats = now()
 
-    assert.ok(ts >= bts - before + 40)
+    assert.ok(ts >= 40)
     assert.ok(ts <= ats - after + 40)
 
     setTimeout(function () {
@@ -30,7 +30,7 @@ test("seeded", function (assert) {
         var ts = time()
         var ats = now()
 
-        assert.ok(ts >= bts - before + 40)
+        assert.ok(ts >= 40)
         assert.ok(ts <= ats - after + 40)
 
         assert.end()


### PR DESCRIPTION
Sometimes bts - before can be 1 and ts 40,
because test cannot assume correctly what v8
is optimizing under the hood.